### PR TITLE
Relax the visibility of some api methods to support porting pdftk

### DIFF
--- a/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
+++ b/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
@@ -157,7 +157,7 @@ public class PdfPageLabels {
     /** Gets the page label dictionary to insert into the document.
      * @return the page label dictionary
      */    
-    PdfDictionary getDictionary(PdfWriter writer) {
+    protected PdfDictionary getDictionary(PdfWriter writer) {
         try {
             return PdfNumberTree.writeTree(map, writer);
         }

--- a/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -66,7 +66,7 @@ import com.lowagie.text.pdf.interfaces.PdfViewerPreferences;
 import com.lowagie.text.pdf.internal.PdfViewerPreferencesImp;
 import com.lowagie.text.xml.xmp.XmpReader;
 
-class PdfStamperImp extends PdfWriter {
+public class PdfStamperImp extends PdfWriter {
     HashMap readers2intrefs = new HashMap();
     HashMap readers2file = new HashMap();
     RandomAccessFileOrArray file;
@@ -105,7 +105,7 @@ class PdfStamperImp extends PdfWriter {
      * @throws DocumentException on error
      * @throws IOException
      */
-    PdfStamperImp(PdfReader reader, OutputStream os, char pdfVersion, boolean append) throws DocumentException, IOException {
+    protected PdfStamperImp(PdfReader reader, OutputStream os, char pdfVersion, boolean append) throws DocumentException, IOException {
         super(new PdfDocument(), os);
         if (!reader.isOpenedWithFullPermissions()) {
             throw new BadPasswordException("PdfReader not opened with owner password");
@@ -157,7 +157,7 @@ class PdfStamperImp extends PdfWriter {
         initialXrefSize = reader.getXrefSize();
     }
 
-    void close(HashMap moreInfo) throws IOException {
+    protected void close(HashMap moreInfo) throws IOException {
         if (closed) {
             return;
         }
@@ -682,7 +682,7 @@ class PdfStamperImp extends PdfWriter {
         return ps;
     }
 
-    PdfContentByte getUnderContent(int pageNum) {
+    protected PdfContentByte getUnderContent(int pageNum) {
         if (pageNum < 1 || pageNum > reader.getNumberOfPages())
             return null;
         PageStamp ps = getPageStamp(pageNum);
@@ -691,7 +691,7 @@ class PdfStamperImp extends PdfWriter {
         return ps.under;
     }
 
-    PdfContentByte getOverContent(int pageNum) {
+    protected PdfContentByte getOverContent(int pageNum) {
         if (pageNum < 1 || pageNum > reader.getNumberOfPages())
             return null;
         PageStamp ps = getPageStamp(pageNum);
@@ -826,14 +826,14 @@ class PdfStamperImp extends PdfWriter {
         return body.size() > 1;
     }
 
-    AcroFields getAcroFields() {
+    protected AcroFields getAcroFields() {
         if (acroFields == null) {
             acroFields = new AcroFields(reader, this);
         }
         return acroFields;
     }
 
-    void setFormFlattening(boolean flat) {
+    protected void setFormFlattening(boolean flat) {
         this.flat = flat;
     }
 

--- a/src/main/java/com/lowagie/text/pdf/XfdfReader.java
+++ b/src/main/java/com/lowagie/text/pdf/XfdfReader.java
@@ -51,6 +51,7 @@ package com.lowagie.text.pdf;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,13 +86,15 @@ public class XfdfReader implements SimpleXMLDocHandler {
      * @throws IOException on error
      */    
     public XfdfReader(String filename) throws IOException {
-        FileInputStream fin = null;
+        this(new FileInputStream(filename));
+    }
+
+    public XfdfReader(InputStream fin) throws IOException {
         try {
-            fin = new FileInputStream(filename);
             SimpleXMLParser.parse(this, fin);
         }
         finally {
-            try{if (fin != null) {fin.close();}}catch(Exception e){}
+            try{fin.close();}catch(Exception e){}
         }
     }
     
@@ -100,7 +103,7 @@ public class XfdfReader implements SimpleXMLDocHandler {
      * @throws IOException on error
      */    
     public XfdfReader(byte xfdfIn[]) throws IOException {
-        SimpleXMLParser.parse( this, new ByteArrayInputStream(xfdfIn));
+        this(new ByteArrayInputStream(xfdfIn));
    }
     
     /** Gets all the fields. The map is keyed by the fully qualified


### PR DESCRIPTION
I was experimenting with a pdftk ported to this library and noticed that some of the internal APIs need to be exposed to be able to use them. I hope these are not too invasive or there is another way to access them.